### PR TITLE
update ES mappings for building level aggregation

### DIFF
--- a/python/dsra_postgres2es.py
+++ b/python/dsra_postgres2es.py
@@ -94,6 +94,9 @@ def main():
                 'properties': {
                     'coordinates': {
                         'type': 'geo_point'
+                    },
+                    'geometry': {
+                        'type': 'geo_shape'
                     }
                 }
             }

--- a/python/dsra_postgres2es.py
+++ b/python/dsra_postgres2es.py
@@ -68,7 +68,7 @@ def main():
                        auth.get('es', 'es_pw')))
     if es.indices.exists(view):
         es.indices.delete(view)
-    if args.idField == 'sauid':
+    if args.idField.lower() == 'sauid':
         id_field = 'Sauid'
         settings = {
             'settings': {
@@ -83,7 +83,7 @@ def main():
                 }
             }
         }
-    elif args.idField == 'building':
+    elif args.idField.lower() == 'building':
         id_field = 'AssetID'
         settings = {
             'settings': {
@@ -104,7 +104,7 @@ def main():
     es.indices.create(index=view, body=settings, request_timeout=90)
 
     while True:
-        if args.idField == 'sauid':
+        if args.idField.lower() == 'sauid':
             id_field = 'Sauid'
             sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_poly) \
                 FROM results_dsra_{eqScenario}.{view} \
@@ -115,7 +115,7 @@ def main():
                                            'limit': limit,
                                            'offset': offset})
 
-        elif args.idField == 'building':
+        elif args.idField.lower() == 'building':
             id_field = 'AssetID'
             sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_point) \
                 FROM results_dsra_{eqScenario}.{view} \
@@ -151,7 +151,7 @@ def main():
 
                 # Format table into a geojson format for ES/Kibana consumption
                 for row in rows:
-                    if args.idField == 'sauid':
+                    if args.idField.lower() == 'sauid':
                         feature = {
                             'type': 'Feature',
                             'geometry': json.loads(row[geomIndex]),
@@ -162,7 +162,7 @@ def main():
                                 value = row[index]
                                 feature['properties'][column] = value
 
-                    elif args.idField == 'building':
+                    elif args.idField.lower() == 'building':
                         coordinates = json.loads(row[geomIndex])['coordinates']
                         feature = {
                             'type': 'Feature',

--- a/python/exposure_postgres2es.py
+++ b/python/exposure_postgres2es.py
@@ -101,8 +101,8 @@ def main():
     view = "nhsl_physical_exposure_{type}_{aggregation}".format(**{
         'type': args.type,
         'aggregation': args.aggregation[0].lower()})
-    id_field = args.idField    
-    
+    id_field = args.idField
+
     # es = Elasticsearch()
     es = Elasticsearch([auth.get('es', 'es_endpoint')],
                        http_auth=(auth.get('es', 'es_un'),

--- a/python/hazardThreat_postgres2es.py
+++ b/python/hazardThreat_postgres2es.py
@@ -70,11 +70,11 @@ def main():
             },
             'mappings': {
                 'properties': {
+                    'coordinates': {
+                        'type': 'geo_point'
+                    },
                     'geometry': {
                         'type': 'geo_shape'
-                    },
-                    'geom_point': {
-                        'type': 'geo_point'
                     }
                 }
             }
@@ -102,15 +102,30 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            feature = {
-                'type': 'Feature',
-                'geometry': json.loads(row[geomIndex]),
-                'properties': {},
-            }
-            for index, column in enumerate(columns):
-                if column != "st_asgeojson":
-                    value = row[index]
-                    feature['properties'][column] = value
+            if args.idField == 'sauid':
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
+            elif args.idField == 'building':
+                coordinates = json.loads(row[geomIndex])['coordinates']
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'coordinates': coordinates,
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
             feature_collection['features'].append(feature)
         geojsonobject = json.dumps(feature_collection,
                                    indent=2,

--- a/python/hazardThreat_postgres2es.py
+++ b/python/hazardThreat_postgres2es.py
@@ -58,7 +58,7 @@ def main():
                 }
             }
         }
-    elif args.idField == 'building':
+    elif args.idField.lower() == 'building':
         id_field = 'AssetID'
         sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_point) \
             FROM results_nhsl_hazard_threat.{view}'.format(**{
@@ -102,7 +102,7 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            if args.idField == 'sauid':
+            if args.idField.lower() == 'sauid':
                 feature = {
                     'type': 'Feature',
                     'geometry': json.loads(row[geomIndex]),
@@ -113,7 +113,7 @@ def main():
                         value = row[index]
                         feature['properties'][column] = value
 
-            elif args.idField == 'building':
+            elif args.idField.lower() == 'building':
                 coordinates = json.loads(row[geomIndex])['coordinates']
                 feature = {
                     'type': 'Feature',

--- a/python/psra_postgres2es.py
+++ b/python/psra_postgres2es.py
@@ -68,12 +68,11 @@ def main():
             },
             'mappings': {
                 'properties': {
+                    'coordinates': {
+                        'type': 'geo_point'
+                    },
                     'geometry': {
-                        'properties': {
-                            'coordinates': {
-                                'type': 'geo_point'
-                            }
-                        }
+                        'type': 'geo_shape'
                     }
                 }
             }
@@ -101,15 +100,30 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            feature = {
-                'type': 'Feature',
-                'geometry': json.loads(row[geomIndex]),
-                'properties': {},
-            }
-            for index, column in enumerate(columns):
-                if column != "st_asgeojson":
-                    value = row[index]
-                    feature['properties'][column] = value
+            if args.idField == 'sauid':
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
+            elif args.idField == 'building':
+                coordinates = json.loads(row[geomIndex])['coordinates']
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'coordinates': coordinates,
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
             feature_collection['features'].append(feature)
         geojsonobject = json.dumps(feature_collection,
                                    indent=2,

--- a/python/psra_postgres2es.py
+++ b/python/psra_postgres2es.py
@@ -35,7 +35,7 @@ def main():
         'province': args.province,
         'dbview': args.dbview,
         'idField': args.idField[0]}).lower()
-    if args.idField == 'sauid':
+    if args.idField.lower() == 'sauid':
         id_field = 'Sauid'
         sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_poly) \
             FROM results_psra_{province}.{view}'.format(**{
@@ -55,7 +55,7 @@ def main():
             }
         }
 
-    elif args.idField == 'building':
+    elif args.idField.lower() == 'building':
         id_field = 'AssetID'
         sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_point) \
             FROM results_psra_{province}.{view}'.format(**{
@@ -100,7 +100,7 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            if args.idField == 'sauid':
+            if args.idField.lower() == 'sauid':
                 feature = {
                     'type': 'Feature',
                     'geometry': json.loads(row[geomIndex]),
@@ -111,7 +111,7 @@ def main():
                         value = row[index]
                         feature['properties'][column] = value
 
-            elif args.idField == 'building':
+            elif args.idField.lower() == 'building':
                 coordinates = json.loads(row[geomIndex])['coordinates']
                 feature = {
                     'type': 'Feature',

--- a/python/riskDynamics_postgres2es.py
+++ b/python/riskDynamics_postgres2es.py
@@ -112,7 +112,7 @@ def main():
                         value = row[index]
                         feature['properties'][column] = value
 
-            elif args.idField.lower() == 'ghslID':
+            elif args.idField == 'ghslID':
                 coordinates = json.loads(row[geomIndex])['coordinates']
                 feature = {
                     'type': 'Feature',

--- a/python/riskDynamics_postgres2es.py
+++ b/python/riskDynamics_postgres2es.py
@@ -69,11 +69,11 @@ def main():
             },
             'mappings': {
                 'properties': {
+                    'coordinates': {
+                        'type': 'geo_point'
+                    },
                     'geometry': {
                         'type': 'geo_shape'
-                    },
-                    'geom_point': {
-                        'type': 'geo_point'
                     }
                 }
             }
@@ -101,15 +101,30 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            feature = {
-                'type': 'Feature',
-                'geometry': json.loads(row[geomIndex]),
-                'properties': {},
-            }
-            for index, column in enumerate(columns):
-                if column != "st_asgeojson":
-                    value = row[index]
-                    feature['properties'][column] = value
+            if args.idField == 'sauid':
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
+            elif args.idField == 'building':
+                coordinates = json.loads(row[geomIndex])['coordinates']
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'coordinates': coordinates,
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
             feature_collection['features'].append(feature)
         geojsonobject = json.dumps(feature_collection,
                                    indent=2,

--- a/python/riskDynamics_postgres2es.py
+++ b/python/riskDynamics_postgres2es.py
@@ -101,7 +101,7 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            if args.idField == 'sauid':
+            if args.idField.lower() == 'sauid':
                 feature = {
                     'type': 'Feature',
                     'geometry': json.loads(row[geomIndex]),
@@ -112,7 +112,7 @@ def main():
                         value = row[index]
                         feature['properties'][column] = value
 
-            elif args.idField == 'building':
+            elif args.idField.lower() == 'ghslID':
                 coordinates = json.loads(row[geomIndex])['coordinates']
                 feature = {
                     'type': 'Feature',

--- a/python/socialFabric_postgres2es.py
+++ b/python/socialFabric_postgres2es.py
@@ -71,11 +71,11 @@ def main():
             },
             'mappings': {
                 'properties': {
+                    'coordinates': {
+                        'type': 'geo_point'
+                    },
                     'geometry': {
                         'type': 'geo_shape'
-                    },
-                    'geom_point': {
-                        'type': 'geo_point'
                     }
                 }
             }
@@ -103,15 +103,30 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            feature = {
-                'type': 'Feature',
-                'geometry': json.loads(row[geomIndex]),
-                'properties': {},
-            }
-            for index, column in enumerate(columns):
-                if column != "st_asgeojson":
-                    value = row[index]
-                    feature['properties'][column] = value
+            if args.idField == 'sauid':
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
+            elif args.idField == 'building':
+                coordinates = json.loads(row[geomIndex])['coordinates']
+                feature = {
+                    'type': 'Feature',
+                    'geometry': json.loads(row[geomIndex]),
+                    'coordinates': coordinates,
+                    'properties': {},
+                }
+                for index, column in enumerate(columns):
+                    if column != "st_asgeojson":
+                        value = row[index]
+                        feature['properties'][column] = value
+
             feature_collection['features'].append(feature)
         geojsonobject = json.dumps(feature_collection,
                                    indent=2,

--- a/python/socialFabric_postgres2es.py
+++ b/python/socialFabric_postgres2es.py
@@ -59,7 +59,7 @@ def main():
                 }
             }
         }
-    elif args.idField == 'building':
+    elif args.idField.lower() == 'building':
         id_field = 'AssetID'
         sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom_point) \
             FROM results_nhsl_hazard_threat.{view}'.format(**{
@@ -103,7 +103,7 @@ def main():
 
         # Format the table into a geojson format for ES/Kibana consumption
         for row in rows:
-            if args.idField == 'sauid':
+            if args.idField.lower() == 'sauid':
                 feature = {
                     'type': 'Feature',
                     'geometry': json.loads(row[geomIndex]),
@@ -114,7 +114,7 @@ def main():
                         value = row[index]
                         feature['properties'][column] = value
 
-            elif args.idField == 'building':
+            elif args.idField.lower() == 'building':
                 coordinates = json.loads(row[geomIndex])['coordinates']
                 feature = {
                     'type': 'Feature',


### PR DESCRIPTION
Need to include both a `geometry` mapping as well as a `coordinates`mapping in the building level aggregation index so that the point geometries can be viewable in Kibana maps but also query-able using spatial queries from ElasticSearch or PyGeoAPI. 

For ES and PyGeoAPI queries, coordinates are stored as geo_shape. A point is documented as a valid shape type:
https://www.elastic.co/guide/en/elasticsearch/reference/7.7/geo-shape.html

For Kibana maps, coordinates are stored as geo_point:
https://www.elastic.co/guide/en/elasticsearch/reference/7.7/geo-point.html

There is further room for improvement here. 
