### PR TITLE
Speed up PostGIS database with with synchronous_commit=off and more

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,5 +78,7 @@ services:
             POSTGRES_USER: ${POSTGRES_USER}
             POSTGRES_PASS: ${POSTGRES_PASS}
             POSTGRES_DB: ${DB_NAME}
-        
+
+        command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
+
         restart: on-failure


### PR DESCRIPTION
Fixes #77

----

Not quite ready yet:
* `ps auxwww` does shows a `postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=off` process, but do need to verify if the command-line options actually reach the PostgreSQL server
* Need to understand how to read the logs
* I moved my /var/lib/docker/volumes where the PostgreSQL database resides to an NFS mount (for no particularly good reason, in retrospect), so that may affect the benchmark.