### PR TITLE
docker-compose: Use different names for "build" and "image"

### DIFF
--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -27,7 +27,7 @@ services:
             - 9200:9200
     
     pygeoapi-opendrr:
-        image: opendrr/pygeoapi
+        image: opendrr-pygeoapi
         build: ./pygeoapi
         
         ports:
@@ -39,7 +39,7 @@ services:
         restart: unless-stopped
     
     db-opendrr:
-        image: postgis/postgis
+        image: opendrr-postgis
         build: ./postgis
         shm_size: 1g
  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 services:
 
     python-opendrr:
-        image: opendrr/python-env
+        image: opendrr-python-env
         build: ./python
 
         env_file:
@@ -47,7 +47,7 @@ services:
             - 9200:9200
     
     pygeoapi-opendrr:
-        image: opendrr/pygeoapi
+        image: opendrr-pygeoapi
         build: ./pygeoapi
         
         ports:
@@ -59,7 +59,7 @@ services:
         restart: unless-stopped
     
     db-opendrr:
-        image: postgis/postgis
+        image: opendrr-postgis
         build: ./postgis
         shm_size: 1g
  


### PR DESCRIPTION
to prevent "max depth exceeded" error

Fixes #96