### PR TITLE
docker-compose: Fix named volume "pg-data" in db-opendrr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
             - .env
         
         volumes: 
-            - pg-data:/var/lib/postgresql
+            - pg-data:/var/lib/postgresql/data
             - opendrr-scripts:/usr/src/app
 
         ports: 


### PR DESCRIPTION
Our pg-data named volume mounted to /var/lib/postgresql was always empty
because an anonymous volume mounted to /var/lib/postgresql/data was
already defined in the Dockerfile of the postgres image from which our
postgis image is based.  See:

* https://stackoverflow.com/questions/41637505/how-to-persist-data-in-a-dockerized-postgres-database-using-volumes
* https://github.com/docker-library/postgres/issues/103
* https://github.com/docker-library/postgres/issues/265
* https://github.com/docker-library/postgres/blob/master/13/Dockerfile#L180-L183
* https://github.com/postgis/docker-postgis/blob/master/13-3.1/Dockerfile