### PR TITLE
Update source to openquake inputs

### DIFF
--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -385,7 +385,7 @@ read_github_token() {
 # from the OpenDRR/model-factory repository
 get_model_factory_scripts() {
   # TODO: Make this more robust
-  RUN git clone https://github.com/OpenDRR/model-factory.git --depth 1 || (cd model-factory ; RUN git pull)
+  RUN git clone https://github.com/OpenDRR/model-factory.git --branch update_source_to_openquake-inputs --depth 1 || (cd model-factory ; RUN git pull)
 
   # Copy model-factory scripts to working directory
   # TODO: Find ways to keep these scripts in their place without copying them all to WORKDIR
@@ -400,7 +400,7 @@ get_git_lfs_pointers_of_csv_files() {
   LOG '## Fetch Git LFS pointers of CSV files for "oid sha256"'
   mkdir -p git
   ( cd git &&
-    for repo in canada-srm2 model-inputs scenario-catalogue; do
+    for repo in canada-srm2 model-inputs openquake-inputs scenario-catalogue; do
       RUN git clone --filter=blob:none --no-checkout "https://${GITHUB_TOKEN}@github.com/OpenDRR/${repo}.git"
       is_dry_run || \
         ( cd $repo && \
@@ -459,8 +459,8 @@ import_physical_exposure_model() {
   # Physical Exposure
   LOG "## Importing Physical Exposure Model into PostGIS"
 
-  RUN fetch_csv model-inputs \
-    exposure/general-building-stock/BldgExpRef_CA_master_v3p1.csv
+  RUN fetch_csv openquake-inputs \
+    exposure/general-building-stock/BldgExpRef_CA_master_v3p2.csv
   RUN run_psql Create_table_canada_exposure.sql
 
   RUN fetch_csv model-inputs \
@@ -472,10 +472,10 @@ import_vs30_model() {
   # VS30
   LOG "## Importing VS30 Model into PostGIS"
 
-  RUN fetch_csv model-inputs \
+  RUN fetch_csv openquake-inputs \
     earthquake/sites/regions/vs30_CAN_site_model_xref.csv
 
-  RUN fetch_csv model-inputs \
+  RUN fetch_csv openquake-inputs \
     earthquake/sites/regions/site-vgrid_CA.csv
 
   RUN run_psql Create_table_vs_30_CAN_site_model.sql
@@ -486,19 +486,19 @@ import_census_data() {
   # Census Data
   LOG "## Importing Census Data"
 
-  RUN fetch_csv model-inputs \
-    exposure/census-ref-sauid/census-attributes-2016.csv?ref=ab1b2d58dcea80a960c079ad2aff337bc22487c5
+  RUN fetch_csv openquake-inputs \
+    exposure/census-ref-sauid/census-attributes-2016.csv
   RUN run_psql Create_table_2016_census_v3.sql
 }
 
 import_sovi() {
   LOG "## Importing Sovi"
   # Need to source tables
-  RUN fetch_csv model-inputs \
+  RUN fetch_csv openquake-inputs \
     social-vulnerability/social-vulnerability-census_2021.csv
-  RUN fetch_csv model-inputs \
+  RUN fetch_csv openquake-inputs \
     social-vulnerability/social-vulnerability-index_2021.csv
-  RUN fetch_csv model-inputs \
+  RUN fetch_csv openquake-inputs \
     social-vulnerability/sovi_thresholds_2021.csv
 
   RUN run_psql Create_table_sovi_index_canada_v2.sql
@@ -508,35 +508,35 @@ import_sovi() {
 
 import_luts() {
   LOG "## Importing LUTs"
-  RUN fetch_csv model-inputs \
-    exposure/general-building-stock/documentation/collapse_probability.csv?ref=73d15ca7e48291ee98d8a8dd7fb49ae30548f34e
+  RUN fetch_csv openquake-inputs \
+    exposure/general-building-stock/1. documentation/collapse_probability.csv
   RUN run_psql Create_collapse_probability_table.sql
 }
 
-import_retrofit_costs() {
-  LOG "## Retrofit Costs"
-  RUN fetch_csv model-inputs \
-    exposure/general-building-stock/documentation/retrofit_costs.csv?ref=73d15ca7e48291ee98d8a8dd7fb49ae30548f34e
-  RUN run_psql Create_retrofit_costs_table.sql
-}
+# import_retrofit_costs() {
+#   LOG "## Retrofit Costs"
+#   RUN fetch_csv openquake-inputs \
+#     exposure/general-building-stock/1. documentation/retrofit_costs.csv
+#   RUN run_psql Create_retrofit_costs_table.sql
+# }
 
 import_ghsl() {
   LOG "## Importing GHSL"
-  RUN fetch_csv model-inputs \
-    natural-hazards/mh-intensity-ghsl.csv?ref=ab1b2d58dcea80a960c079ad2aff337bc22487c5
+  RUN fetch_csv openquake-inputs \
+    natural-hazards/mh-intensity-ghsl.csv
   RUN run_psql Create_table_GHSL.sql
 }
 
 import_mh_intensity() {
   LOG "## Importing MH Intensity"
-  RUN fetch_csv model-inputs \
-    natural-hazards/HTi_sauid_2021.csv
+  RUN fetch_csv openquake-inputs \
+    natural-hazards/HTi_sauid.csv
 }
 
 import_hazard_threat_thresholds() {
   LOG "## Importing Hazard Threat Thresholds"
-  RUN fetch_csv model-inputs \
-    natural-hazards/HTi_thresholds_2021.csv
+  RUN fetch_csv openquake-inputs \
+    natural-hazards/HTi_thresholds.csv
 }
 
 post_process_mh_tables() {

--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -478,6 +478,9 @@ import_vs30_model() {
   RUN fetch_csv openquake-inputs \
     earthquake/sites/regions/site-vgrid_CA.csv
 
+  #Correct CRLF 
+  sed -i 's/\r//g' /usr/src/app/site-vgrid_CA.csv
+
   RUN run_psql Create_table_vs_30_CAN_site_model.sql
   RUN run_psql Create_table_vs_30_CAN_site_model_xref.sql
 }

--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -495,9 +495,9 @@ import_sovi() {
   LOG "## Importing Sovi"
   # Need to source tables
   RUN fetch_csv openquake-inputs \
-    social-vulnerability/social-vulnerability-census_2021.csv
+    social-vulnerability/social-vulnerability-census.csv
   RUN fetch_csv openquake-inputs \
-    social-vulnerability/social-vulnerability-index_2021.csv
+    social-vulnerability/social-vulnerability-index.csv
   RUN fetch_csv openquake-inputs \
     social-vulnerability/sovi_thresholds_2021.csv
 
@@ -509,16 +509,16 @@ import_sovi() {
 import_luts() {
   LOG "## Importing LUTs"
   RUN fetch_csv openquake-inputs \
-    exposure/general-building-stock/1. documentation/collapse_probability.csv
+    exposure/general-building-stock/1.%20documentation/collapse_probability.csv
   RUN run_psql Create_collapse_probability_table.sql
 }
 
-# import_retrofit_costs() {
-#   LOG "## Retrofit Costs"
-#   RUN fetch_csv openquake-inputs \
-#     exposure/general-building-stock/1. documentation/retrofit_costs.csv
-#   RUN run_psql Create_retrofit_costs_table.sql
-# }
+import_retrofit_costs() {
+  LOG "## Retrofit Costs"
+  RUN fetch_csv openquake-inputs \
+    exposure/general-building-stock/1. documentation/retrofit_costs.csv
+  RUN run_psql Create_retrofit_costs_table.sql
+}
 
 import_ghsl() {
   LOG "## Importing GHSL"
@@ -537,13 +537,17 @@ import_hazard_threat_thresholds() {
   LOG "## Importing Hazard Threat Thresholds"
   RUN fetch_csv openquake-inputs \
     natural-hazards/HTi_thresholds.csv
+  RUN fetch_csv openquake-inputs \
+    natural-hazards/hazard_threat_rating_thresholds.csv
 }
 
 post_process_mh_tables() {
   RUN run_psql Create_table_mh_intensity_canada_v2.sql
   RUN run_psql Create_table_mh_thresholds.sql
-  RUN run_psql Create_MH_risk_building_ALL.sql
-  RUN run_psql Create_MH_risk_sauid_ALL.sql
+  RUN run_psql Create_table_mh_rating_thresholds.sql
+  RUN run_psql Create_MH_risk_sauid_prioritization_prereq_tables.sql
+  RUN run_psql Create_MH_risk_sauid_prioritization_Canada.sql
+  # RUN run_psql Create_MH_risk_sauid_ALL.sql
 }
 
 copy_ancillary_tables() {
@@ -567,7 +571,7 @@ generate_indicators() {
   RUN run_psql Create_physical_exposure_site_level_indicators_PhysicalExposure_ste.sql
   RUN run_psql Create_risk_dynamics_indicators.sql
   RUN run_psql Create_social_vulnerability_sauid_indicators_SocialFabric.sql
-  RUN run_psql Create_MH_risk_sauid_ALL.sql
+  # RUN run_psql Create_MH_risk_sauid_ALL.sql
 }
 
 ############################################################################################
@@ -599,11 +603,12 @@ import_raw_psra_tables() {
   LOG "### cHazard"
   RUN fetch_psra_csv_from_model cHazard
 
-  for PT in "${PT_LIST[@]}"; do
-    ( cd "cHazard/$PT"
-      RUN python3 /usr/src/app/PSRA_hCurveTableCombine.py --hCurveDir="/usr/src/app/cHazard/$PT/"
-    )
-  done
+  # This was only needed when the cHazard data was divided by economic region
+  # for PT in "${PT_LIST[@]}"; do
+  #   ( cd "cHazard/$PT"
+  #     RUN python3 /usr/src/app/PSRA_hCurveTableCombine.py --hCurveDir="/usr/src/app/cHazard/$PT/"
+  #   )
+  # done
 
   LOG "### eDamage"
   RUN fetch_psra_csv_from_model eDamage
@@ -851,7 +856,7 @@ main() {
   RUN import_census_data
   RUN import_sovi
   RUN import_luts
-  RUN import_retrofit_costs
+  # RUN import_retrofit_costs
   RUN import_ghsl
   RUN import_mh_intensity
   RUN import_hazard_threat_thresholds

--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -548,8 +548,8 @@ post_process_mh_tables() {
   RUN run_psql Create_table_mh_intensity_canada_v2.sql
   RUN run_psql Create_table_mh_thresholds.sql
   RUN run_psql Create_table_mh_rating_thresholds.sql
-  RUN run_psql Create_MH_risk_sauid_prioritization_prereq_tables.sql
-  RUN run_psql Create_MH_risk_sauid_prioritization_Canada.sql
+  # RUN run_psql Create_MH_risk_sauid_prioritization_prereq_tables.sql
+  # RUN run_psql Create_MH_risk_sauid_prioritization_Canada.sql
   # RUN run_psql Create_MH_risk_sauid_ALL.sql
 }
 
@@ -574,6 +574,8 @@ generate_indicators() {
   RUN run_psql Create_physical_exposure_site_level_indicators_PhysicalExposure_ste.sql
   RUN run_psql Create_risk_dynamics_indicators.sql
   RUN run_psql Create_social_vulnerability_sauid_indicators_SocialFabric.sql
+  RUN run_psql Create_MH_risk_sauid_prioritization_prereq_tables.sql
+  RUN run_psql Create_MH_risk_sauid_prioritization_Canada.sql
   # RUN run_psql Create_MH_risk_sauid_ALL.sql
 }
 


### PR DESCRIPTION
Migrate input data from `model-inputs` repo to `openquake-inputs` repo.

- Changes to source repos
- Changes to filenames
- Removal of retrofit costs

Changes defined by requirements outlined in:
https://github.com/OpenDRR/opendrr-api/issues/104

Closes #104 