### PR TITLE
Fix "./add_data.sh not found" error on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -9,6 +9,7 @@ COPY . .
 #RUN chmod +x docker-entrypoint.sh && chmod +x add_data.sh
 RUN chmod +x add_data.sh && \
     apt-get update && \
-    apt-get install -y eatmydata git git-lfs jq time
+    apt-get install -y dos2unix eatmydata git git-lfs jq time && \
+    dos2unix add_data.sh
 #ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
 CMD ./add_data.sh

--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -363,7 +363,7 @@ check_environment_variables() {
 read_github_token() {
   LOG "## Read GitHub token from config.ini"
   # See https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/
-  GITHUB_TOKEN=$(sed -n -r 's/^ *github_token *= *([A-Za-z0-9_]+)/\1/p' config.ini)
+  GITHUB_TOKEN=$(sed -n -r 's/^ *github_token *= *([A-Za-z0-9_]+).*/\1/p' config.ini)
 
   INFO "GITHUB_TOKEN is ${#GITHUB_TOKEN} characters in length"
 


### PR DESCRIPTION
"docker compose up --build" failed to run add_data.sh on Windows
partly because Git for Windows defaults to "Checkout Windows-style"
where "Git will convert LF to CRLF when checking out text files"...

... but bash scripts with CRLF line ending, such as add_data.sh that
got converted to CRLF on Windows and copied as-is into the
opendrr-scripts volume, simply fails to run in the Linux-based container.

This commit resolves the issue in two ways:

 1. Running "dos2unix add_data.sh" to convert CRLF back to LF in
    python/Dockerfile;
    Credit: https://github.com/postlight/headless-wp-starter/issues/171

 2. Enforcing *.sh files to have LF line endings in .gitattributes;
    Credit: https://danhwashere.com/gitattributes-tips

Reference:

The default line endings configuration recommended by Git for Windows
is as follows:

    Configuring the line ending conversions
    How should Git treat line endings in text files?

     1. Checkout Windows-style, commit Unix-style line endings

        Git will convert LF to CRLF when checking out text files. When committing
        text files, CRLF will be converted to LF. For cross-platform projects,
        this is the recommended setting on Windows ("core.autocrlf" is set to "true").

From https://github.com/git-for-windows/build-extra/blob/main/installer/install.iss