### PR TITLE
Bump Elasticsearch and Kibana Docker images from 7.7.1 to 7.12.0

### DIFF
--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -6,7 +6,7 @@ volumes:
 services:
 
     kibana-opendrr:
-        image: kibana:7.7.1
+        image: kibana:7.12.0
         
         environment:
             ELASTICSEARCH_HOSTS: http://elasticsearch-opendrr:9200
@@ -18,7 +18,7 @@ services:
             - elasticsearch-opendrr
     
     elasticsearch-opendrr: 
-        image: elasticsearch:7.7.1
+        image: elasticsearch:7.12.0
         
         environment:
             - discovery.type=single-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
 
     kibana-opendrr:
-        image: kibana:7.7.1
+        image: kibana:7.12.0
         
         environment:
             ELASTICSEARCH_HOSTS: http://elasticsearch-opendrr:9200
@@ -34,7 +34,7 @@ services:
             - elasticsearch-opendrr
     
     elasticsearch-opendrr: 
-        image: elasticsearch:7.7.1
+        image: elasticsearch:7.12.0
         
         environment:
             - discovery.type=single-node


### PR DESCRIPTION
This is to match the version running in the staging environment, as suggested by Drew (@drotheram) during the Cloud Tech meeting on Wed 2021-07-21.

***

On closer look, python/kibanaSavedObjects.ndjson also contains references to the previous version 7.7.1, used in

```
curl -X POST -H "securitytenant: global" "${KIBANA_ENDPOINT}/api/saved_objects/_import" \
    -H "kbn-xsrf: true" --form file=@kibanaSavedObjects.ndjson
```

in add_data.sh.  

According to https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html:

> saved objects can only be imported into the same version, a newer minor on the same major, or the next major.

So I assume that importing 7.7.1 saved objects into 7.12.0 should be OK.  (fingers crossed :crossed_fingers:)  :-)