### PR TITLE
Fix shebang line for Python scripts

### DIFF
--- a/python/dsraAllScenariosCduid_postgres2es.py
+++ b/python/dsraAllScenariosCduid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/dsraAllScenariosCsduid_postgres2es.py
+++ b/python/dsraAllScenariosCsduid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/dsraAllScenariosDauid_postgres2es.py
+++ b/python/dsraAllScenariosDauid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/dsraAllScenariosEruid_postgres2es.py
+++ b/python/dsraAllScenariosEruid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/dsraAllScenariosSauid_postgres2es.py
+++ b/python/dsraAllScenariosSauid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/dsra_postgres2es.py
+++ b/python/dsra_postgres2es.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # =================================================================
 #
 # Authors: Drew Rotheram <drew.rotheram@gmail.com>
@@ -18,12 +19,13 @@ from elasticsearch import helpers
 
 '''
 Script to convert DSRA indicator views to ElasticSearch Index
-Can be run from the command line with mandatory arguments 
+Can be run from the command line with mandatory arguments
 Run this script with a command like:
 python3 dsra_postgres2es.py --eqScenario="sim6p8_cr2022_rlz_1" --dbview=casualties_agg_view --idField="Sauid"
 '''
 
-#Main Function
+
+# Main Function
 def main():
     logFileName = '{}.log'.format(os.path.splitext(sys.argv[0])[0])
     logging.basicConfig(level=logging.INFO,
@@ -179,11 +181,13 @@ def gendata(data, view, id_field):
             "_source": item
         }
 
-#Function to handle decimal encoder error
+
 def decimal_default(obj):
+    """Handle decimal encoder error."""
     if isinstance(obj, decimal.Decimal):
         return float(obj)
     raise TypeError
+
 
 def get_config_params(args):
     """
@@ -193,14 +197,23 @@ def get_config_params(args):
     configParseObj.read(args)
     return configParseObj
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="script description")
-    parser.add_argument("--eqScenario", type=str, help="Earthquake scenario id", required=True)
-    parser.add_argument("--dbview", type=str, help=" Thematic Database View. Allowable values: (casualties, damage_state, economic_loss, functional_state, recovery, scenario_hazard, scenario_hazard_threat,scenario_rupture, social_disruption)", required=True)
-    parser.add_argument("--idField", type=str, help="Field to use as ElasticSearch Index ID", required=True)
+    parser.add_argument("--eqScenario", type=str, required=True,
+                        help="Earthquake scenario id")
+    parser.add_argument("--dbview", type=str, required=True,
+                        help="""Thematic Database View.
+                        Allowable values: (casualties, damage_state,
+                        economic_loss, functional_state, recovery,
+                        scenario_hazard, scenario_hazard_threat,
+                        scenario_rupture, social_disruption)""")
+    parser.add_argument("--idField", type=str, required=True,
+                        help="Field to use as ElasticSearch Index ID")
     args = parser.parse_args()
-    
+
     return args
 
+
 if __name__ == '__main__':
-    main() 
+    main()

--- a/python/exposure_postgres2es.py
+++ b/python/exposure_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -23,7 +23,8 @@ python3 exposure_postgres2es.py
     --idField="BldgID"
 '''
 
-#Main Function
+
+# Main Function
 def main():
     args = parse_args()
 
@@ -107,8 +108,9 @@ def parse_args():
     #                     help="Field to use as Index ID. AssetID or Sauid",
     #                     required=True)
     args = parser.parse_args()
-    
+
     return args
 
+
 if __name__ == '__main__':
-    main() 
+    main()

--- a/python/hazardThreat_postgres2es.py
+++ b/python/hazardThreat_postgres2es.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/python3
 
 import json
 import os

--- a/python/hexgrid_100km_postgres2es.py
+++ b/python/hexgrid_100km_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hexgrid_10km_postgres2es.py
+++ b/python/hexgrid_10km_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hexgrid_25km_postgres2es.py
+++ b/python/hexgrid_25km_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hexgrid_50km_postgres2es.py
+++ b/python/hexgrid_50km_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hexgrid_5km_postgres2es.py
+++ b/python/hexgrid_5km_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hexgrid_sauid_postgres2es.py
+++ b/python/hexgrid_sauid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/hmaps_postgres2es.py
+++ b/python/hmaps_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -38,6 +38,7 @@ def main():
     table.postgis2es()
 
     return
+
 
 if __name__ == '__main__':
     main()

--- a/python/psra_postgres2es.py
+++ b/python/psra_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -9,6 +9,7 @@
 # =================================================================
 
 import utils
+
 
 def main():
     psraTable = utils.PostGISdataset(
@@ -65,6 +66,7 @@ def main():
     psraTable.postgis2es()
 
     return
+
 
 if __name__ == '__main__':
     main()

--- a/python/sauid_postgres2es.py
+++ b/python/sauid_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada

--- a/python/socialFabric_postgres2es.py
+++ b/python/socialFabric_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -22,6 +22,7 @@ python3 socialFabric_postgres2es.py
     --geometry=geom_poly
     --idField="Sauid"
 '''
+
 
 # Main Function
 def main():
@@ -115,6 +116,7 @@ def parse_args():
     args = parser.parse_args()
 
     return args
+
 
 if __name__ == '__main__':
     main()

--- a/python/srcLoss_postgres2es.py
+++ b/python/srcLoss_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -11,8 +11,9 @@
 import utils
 import argparse
 
+
 def main():
-    args = parse_args()
+    # args = parse_args()
     table = utils.PostGISTable(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -42,6 +43,7 @@ def main():
     table.postgis2es()
 
     return
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="script description")

--- a/python/uhs_postgres2es.py
+++ b/python/uhs_postgres2es.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada
@@ -11,8 +11,9 @@
 import utils
 import argparse
 
+
 def main():
-    args = parse_args()
+    # args = parse_args()
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -32,7 +33,7 @@ def main():
             }
         }),
         view="opendrr_psra_uhs",
-        sqlquerystring = 'SELECT *, ST_AsGeoJSON(geom) \
+        sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                 FROM results_psra_national.psra_uhs \
                 ORDER BY psra_uhs."geom" \
                 LIMIT {limit} \
@@ -42,6 +43,7 @@ def main():
     table.postgis2es()
 
     return
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="script description")

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,5 +1,5 @@
+#!/usr/bin/python3
 # =================================================================
-# !/bin/bash
 # SPDX-License-Identifier: MIT
 #
 # Copyright (C) 2020-2021 Government of Canada


### PR DESCRIPTION
Hey @drotheram,

Sorry for my late review on #129.  While looking through the merged changes just now, I noticed that the [`#!` shebang line](https://en.wikipedia.org/wiki/Shebang_(Unix)) for Bash scripts were inadvertently copied into several Python scripts, so this PR tries to fix that.

There seems to be some differing opinions on which shebang line to use for Python 3, e.g.:

```
#!/usr/bin/env python3
```

and

```
#!/usr/bin/python3
```

I opted for the latter partly because of this in the Debian Python Policy manual:
> Maintainers should not override the Debian Python interpreter using `/usr/bin/env _name_`. This is not advisable as it bypasses Debian’s dependency checking and makes the package vulnerable to incomplete local installations of Python.

(from https://www.debian.org/doc/packaging-manuals/python-policy/index.html#interpreter-location)

and that our opendrr-python-env Docker image, which is based on Debian, has Python 3 installed at `/usr/bin/python3`.

But yes, since we are currently calling these Python scripts by calling `python3` directly, the shebang lines aren't actually used, so this PR is more of a cosmetic change, at least for the time being.  :-)

There are some other minor changes made to appease flake8.  :grin:

Cheers!