### PR TITLE
Pull opendrr/{pygeoapi,python} images from ghcr.io

### DIFF
--- a/pygeoapi/Dockerfile
+++ b/pygeoapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM opendrr/pygeoapi
+FROM ghcr.io/opendrr/pygeoapi
 
 LABEL maintainer="Joost van Ulden <joost.vanulden@canada.ca>"
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM opendrr/python-env
+FROM ghcr.io/opendrr/python-env
 
 LABEL maintainer="Joost van Ulden <joost.vanulden@canada.ca>" 
 


### PR DESCRIPTION
Pull opendrr/pygeoapi and opendrr/python container images from ghcr.io instead of docker.io (Docker Hub, implicit default).

Prerequisite:
- [x] Merging of OpenDRR/python-env#2 and completing the to-do list therein

Fixes OpenDRR/opendrr-platform#128