### PR TITLE
shellcheck: Use tty output format (instead of gcc)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,3 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
+      with:
+        format: tty
+      env:
+        SHELLCHECK_OPTS: --color=always


### PR DESCRIPTION
and set `--color=always` for more informative warning/error log.

The ludeeus/action-shellcheck GitHub Action uses `--format=gcc` by default, e.g.:

```
Warning: ./python/add_data.sh:828:19: warning: Use "${array[@]}" (with quotes) to prevent whitespace problems. [SC2048]
```

which deviates from ShellCheck's original `--format=tty` which is much more helpful, e.g.:

```
In ./python/add_data.sh line 820:
for eqscenario in ${EQSCENARIO_LIST[*]}; do
                  ^-------------------^ SC2048 (warning): Use "${array[@]}" (with quotes) to prevent whitespace problems.

For more information:
  https://www.shellcheck.net/wiki/SC2048 -- Use "${array[@]}" (with quotes) t...
```

especially when the full explanation and examples are often found only on the wiki page e.g. https://www.shellcheck.net/wiki/SC2048

I should have read the https://github.com/marketplace/actions/shellcheck documentation more carefully, as the difference between ludeeus/action-shellcheck GitHub Action log and command-line `shellcheck` output confused me too.  :sweat_smile: