### PR TITLE
pull model-factory release instead of cloning

### DIFF
--- a/python/add_data.sh
+++ b/python/add_data.sh
@@ -435,11 +435,12 @@ read_github_token() {
 # from the OpenDRR/model-factory repository
 get_model_factory_scripts() {
   # TODO: Make this more robust
-RUN git clone https://github.com/OpenDRR/model-factory.git --branch update_dsra_psra_oct2021 --depth 1 || (cd model-factory ; RUN git pull)
+  curl -L -o model-factory.tar.gz https://github.com/OpenDRR/model-factory/archive/refs/tags/v1.3.0.tar.gz
+  tar -xf model-factory.tar.gz
 
   # Copy model-factory scripts to working directory
   # TODO: Find ways to keep these scripts in their place without copying them all to WORKDIR
-  RUN cp model-factory/scripts/*.* .
+  RUN cp model-factory-1.3.0/scripts/*.* .
   #rm -rf model-factory
 }
 


### PR DESCRIPTION
Minor change to add_data.sh to pull model-factory code directly from release rather than cloning the repo. This will help better orchestrate running different versions of the stack as the codebase evolves.

