### PR TITLE
Set Flake8 test to allow --max-line-width=127

### DIFF
--- a/.github/workflows/lintly-flake8.yml
+++ b/.github/workflows/lintly-flake8.yml
@@ -17,4 +17,4 @@ jobs:
           # Fail if "new" violations detected or "any", default "new"
           failIf: new
           # Additional arguments to pass to flake8, default "." (current directory)
-          args: "--ignore=E121,E123,E501 --per-file-ignores=python/gen_pygeoapi_config.py:E501 ."
+          args: "--ignore=E121,E123 --max-line-length=127 ."


### PR DESCRIPTION
Use `--max-line-width=127` instead of ignoring `E501` and make the `args` setting in .github/workflows/lintly-flake8.yml look a bit more clean.