### PR TITLE
Change default pygeoapi port to 5001

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ http://localhost:5601
 
 Check pygeoapi to make sure the collections can be accessed
 
-http://localhost:5000/collections
+http://localhost:5001/collections
 
 Feature collections can be accessed as follows or by clicking on the links provided on the collections page
 
-http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=json&limit=1
+http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=json&limit=1
 
 You should see something similar to:
 
@@ -139,31 +139,31 @@ You should see something similar to:
             "type": "application/geo+json",
             "rel": "self",
             "title": "This document as GeoJSON",
-            "href": "http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=json&amp;limit=1"
+            "href": "http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=json&amp;limit=1"
             },
             {
             "rel": "alternate",
             "type": "application/ld+json",
             "title": "This document as RDF (JSON-LD)",
-            "href": "http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=jsonld&amp;limit=1"
+            "href": "http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=jsonld&amp;limit=1"
             },
             {
             "type": "text/html",
             "rel": "alternate",
             "title": "This document as HTML",
-            "href": "http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=html&amp;limit=1"
+            "href": "http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?f=html&amp;limit=1"
             },
             {
             "type": "application/geo+json",
             "rel": "next",
             "title": "items (next)",
-            "href": "http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?startindex=1&amp;limit=1"
+            "href": "http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?startindex=1&amp;limit=1"
             },
             {
             "type": "application/json",
             "title": "Economic loss buildings",
             "rel": "collection",
-            "href": "http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building"
+            "href": "http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building"
             }
         ],
         "timeStamp": "2020-08-18T22:46:10.513010Z"
@@ -175,17 +175,17 @@ You should see something similar to:
 
 Refer to the pygeoapi documentation for general guidance:
 
-http://localhost:5000/openapi?f=html
+http://localhost:5001/openapi?f=html
 
 > NOTE: querying is currently limited to spatial extent and exact value queries. For more complex querying use Elasticsearch (see below).
 
 #### To filter on a specfic attribute
 
-http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?sH_Mag=7.2
+http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?sH_Mag=7.2
 
 #### To filter using a bounding box
 
-http://localhost:5000/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?bbox=-119,48.8,-118.9,49.8&f=json
+http://localhost:5001/collections/afm7p2_lrdmf_scenario_shakemap_intensity_building/items?bbox=-119,48.8,-118.9,49.8&f=json
 
 ### Querying Elasticsearch
 
@@ -290,7 +290,7 @@ You have two options:
 
 1. Add a "New Connection" by right clicking on the "WFS / OGC API -Features" data type in the browser
 2. Enter a name for your connection (i.e. "OpenDRR")
-3. Enter `http://localhost:5000` in the URL field
+3. Enter `http://localhost:5001` in the URL field
 4. Select "OGC API - Features" in the "Version" dropdown
 4. Click the "OK" button
 

--- a/docker-compose-run.yml
+++ b/docker-compose-run.yml
@@ -31,7 +31,7 @@ services:
         build: ./pygeoapi
         
         ports:
-            - 5000:80
+            - 5001:80
         
         depends_on:
             - elasticsearch-opendrr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         build: ./pygeoapi
         
         ports:
-            - 5000:80
+            - 5001:80
         
         depends_on:
             - elasticsearch-opendrr

--- a/pygeoapi/opendrr.config.yml
+++ b/pygeoapi/opendrr.config.yml
@@ -30,8 +30,8 @@
 server:
     bind:
         host: 0.0.0.0
-        port: 5000
-    url: http://localhost:5000
+        port: 5001
+    url: http://localhost:5001
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     languages:

--- a/python/gen_pygeoapi_config.py
+++ b/python/gen_pygeoapi_config.py
@@ -49,8 +49,8 @@ def main():
 server:
     bind:
         host: 0.0.0.0
-        port: 5000
-    url: http://localhost:5000
+        port: 5001
+    url: http://localhost:5001
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     language: en-US

--- a/python/gen_pygeoapi_config.sh
+++ b/python/gen_pygeoapi_config.sh
@@ -15,10 +15,10 @@ docker build -t temp_image --no-cache .
 
 # instantiate the container
 echo 'Starting the container...'
-docker run -d --name temp_container -p 5000:80 temp_image
+docker run -d --name temp_container -p 5001:80 temp_image
 
 # make sure Elasticsearch is ready prior to creating indexes
-until curl -sSf -XGET --insecure 'http://localhost:5000' > /dev/null; do
+until curl -sSf -XGET --insecure 'http://localhost:5001' > /dev/null; do
     printf 'pygeoapi not ready yet, trying again in 10 seconds \n'
     sleep 10
 done


### PR DESCRIPTION
macOS Monterey runs AirPlay Receiver on port 5000 by default,
which prevents our pygeoapi instance from starting on the same port.
Changing pygeoapi port to 5001 avoids the conflict and makes life
easier for ourselves and others.

See also https://anandtripathi5.medium.com/port-5000-already-in-use-macos-monterey-issue-d86b02edd36c

Thanks to Drew Rotheram for initial research to this problem.


***


Questions:

1. Do we really want this?
2. Port 5001 or another port?
3. @arashmalekz would this change affect you on the AWS side?

Many thanks!

***

Warning/Caveat: I have not tested it with a full stack build!  :sweat_smile: