### PR TITLE
Enforce LF line terminators in postgis/create_db.sh

### DIFF
--- a/postgis/Dockerfile
+++ b/postgis/Dockerfile
@@ -36,4 +36,5 @@ USER root
 COPY create_db.sh /docker-entrypoint-initdb.d/create_db.sh
 COPY schema.sql /schema.sql
 
-RUN chmod +x /docker-entrypoint-initdb.d/create_db.sh
+RUN chmod +x /docker-entrypoint-initdb.d/create_db.sh && \
+    sed -i 's/\r$//g' /docker-entrypoint-initdb.d/create_db.sh


### PR DESCRIPTION
This is to avoid stack build errors that manifests in the db-opendrr log:

    /usr/local/bin/docker-entrypoint.sh:
      /docker-entrypoint-initdb.d/create_db.sh:
        /bin/bash^M: bad interpreter: No such file or directory

and in the python-opendrr log:

    psql:Create_table_canada_exposure.sql:52:
      ERROR:  schema "exposure" does not exist
    LINE 1: CREATE TABLE exposure.canada_exposure(
                         ^

in case postgis/create_db.sh was checked out with CRLF line terminators.

sed is used in this case so as to save a bit of time by not needing to run `apt-get update && apt-get install dos2unix`.

See #124 for a similar fix for python/add_data.sh back in June 2021.

Thanks to @wkhchow for helping me with discovering this issue.