### PR TITLE
add version suffix from config to index name

### DIFF
--- a/python/createESAlias.py
+++ b/python/createESAlias.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+# =================================================================
+# SPDX-License-Identifier: MIT
+#
+# Copyright (C) 2020-2021 Government of Canada
+#
+# Main Authors: Drew Rotheram <drew.rotheram-clarke@canada.ca>
+# 
+# =================================================================
+
+import argparse
+from elasticsearch import Elasticsearch
+
+def get_config_params(args):
+    """
+    Parse Input/Output columns from supplied *.ini file
+    """
+    configParseObj = configparser.ConfigParser()
+    configParseObj.read(args)
+    return configParseObj
+
+auth = get_config_params('config.ini')
+
+es = Elasticsearch([auth.get('es', 'es_endpoint')],
+                           http_auth=(auth.get('es', 'es_un'),
+                                      auth.get('es', 'es_pw')))
+
+indexList = es.cat.indices(index='*_v1.4.0', h='index', s='index:desc').split()
+
+for index in indexList:
+    # print(index)
+    # print(index.rsplit("_", 1)[0])
+    indexBaseName = index.rsplit("_", 1)[0]+"test_alias"
+    # print(index.split("_")[0:-1].join())
+    es.indices.put_alias(index=index, name=indexBaseName)
+

--- a/python/dsraExtents_postgres2es.py
+++ b/python/dsraExtents_postgres2es.py
@@ -13,6 +13,10 @@ import argparse
 
 
 def main():
+
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     dsraTable = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +32,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_shakemap_scenario_extents",
+        view="opendrr_shakemap_scenario_extents_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM gmf.shakemap_scenario_extents \
                     LIMIT {limit} \

--- a/python/dsraShakemap_postgres2es.py
+++ b/python/dsraShakemap_postgres2es.py
@@ -34,8 +34,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_shakemap \
             ORDER BY dsra_{eqScenario}_shakemap."SiteID" \
@@ -60,8 +61,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_1km".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_1km_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_1 \
             ORDER BY dsra_{eqScenario}_sm_hg_1."gridid_1" \
@@ -86,8 +88,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_1km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_1km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_1_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_1_uc."gridid_1" \
@@ -112,8 +115,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_5km".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_5km_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_5 \
             ORDER BY dsra_{eqScenario}_sm_hg_5."gridid_5" \
@@ -138,8 +142,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_5km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_5km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_5_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_5_uc."gridid_5" \
@@ -164,8 +169,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_10km".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_10km_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_10 \
             ORDER BY dsra_{eqScenario}_sm_hg_10."gridid_10" \
@@ -190,8 +196,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_10km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_10km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_10_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_10_uc."gridid_10" \
@@ -216,8 +223,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_25km".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_25km_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_25 \
             ORDER BY dsra_{eqScenario}_sm_hg_25."gridid_25" \
@@ -242,8 +250,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_25km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_25km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_25_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_25_uc."gridid_25" \
@@ -268,8 +277,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_50km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_50km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_50_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_50_uc."gridid_50" \
@@ -294,8 +304,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_100km_uc".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_shakemap_hexgrid_100km_uc_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_sm_hg_100_uc \
             ORDER BY dsra_{eqScenario}_sm_hg_100_uc."gridid_100" \

--- a/python/dsra_postgres2es.py
+++ b/python/dsra_postgres2es.py
@@ -34,8 +34,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_indicators_b".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_indicators_b_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_point) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_indicators_b \
             ORDER BY dsra_{eqScenario}_indicators_b."AssetID" \
@@ -60,8 +61,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_indicators_s".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_indicators_s_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_poly) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_indicators_s \
             ORDER BY dsra_{eqScenario}_indicators_s."Sauid" \
@@ -86,8 +88,9 @@ def main():
                 }
             }
         }),
-        view="opendrr_dsra_{eqScenario}_indicators_csd".format(**{
-            'eqScenario': args.eqScenario}).lower(),
+        view="opendrr_dsra_{eqScenario}_indicators_csd_{version}".format(**{
+            'eqScenario': args.eqScenario,
+            'version': args.version}).lower(),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM results_dsra_{eqScenario}.dsra_{eqScenario}_indicators_csd \
             ORDER BY dsra_{eqScenario}_indicators_csd."csduid" \

--- a/python/exposure_postgres2es.py
+++ b/python/exposure_postgres2es.py
@@ -27,6 +27,9 @@ python3 exposure_postgres2es.py
 # Main Function
 def main():
 
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     # sauid level aggregation
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
@@ -43,7 +46,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_s",
+        view="opendrr_nhsl_physical_exposure_indicators_s_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_poly) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_s \
@@ -72,7 +75,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_b",
+        view="opendrr_nhsl_physical_exposure_indicators_b_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_point) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_b \
@@ -98,7 +101,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_1km",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_1km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_1km \
@@ -124,7 +127,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_1km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_1km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_1km_uc \
@@ -150,7 +153,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_5km",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_5km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_5km \
@@ -176,7 +179,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_5km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_5km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_5km_uc \
@@ -202,7 +205,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_10km",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_10km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_10km \
@@ -228,7 +231,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_10km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_10km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_10km_uc \
@@ -254,7 +257,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_25km",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_25km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_25km \
@@ -280,7 +283,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_25km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_25km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_25km_uc \
@@ -306,7 +309,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_50km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_50km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_50km_uc \
@@ -332,7 +335,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_100km_uc",
+        view="opendrr_nhsl_physical_exposure_indicators_hexgrid_100km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_nhsl_physical_exposure.nhsl_physical_exposure_indicators_hexgrid_100km_uc \

--- a/python/hexgrid_100km_postgres2es.py
+++ b/python/hexgrid_100km_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_hexgrid_100km",
+        view="opendrr_hexgrid_100km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."HexGrid_100km" \
                     ORDER BY "HexGrid_100km"."gridid_100" \

--- a/python/hexgrid_10km_postgres2es.py
+++ b/python/hexgrid_10km_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_hexgrid_10km",
+        view="opendrr_hexgrid_10km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."HexGrid_10km" \
                     ORDER BY "HexGrid_10km"."gridid_10" \

--- a/python/hexgrid_25km_postgres2es.py
+++ b/python/hexgrid_25km_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_hexgrid_25km",
+        view="opendrr_hexgrid_25km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."HexGrid_25km" \
                     ORDER BY "HexGrid_25km"."gridid_25" \

--- a/python/hexgrid_50km_postgres2es.py
+++ b/python/hexgrid_50km_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_hexgrid_50km",
+        view="opendrr_hexgrid_50km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."HexGrid_50km" \
                     ORDER BY "HexGrid_50km"."gridid_50" \

--- a/python/hexgrid_5km_postgres2es.py
+++ b/python/hexgrid_5km_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_hexgrid_5km",
+        view="opendrr_hexgrid_5km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."HexGrid_5km" \
                     ORDER BY "HexGrid_5km"."gridid_5" \

--- a/python/hexgrid_sauid_postgres2es.py
+++ b/python/hexgrid_sauid_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_sauid_hexgrid",
+        view="opendrr_sauid_hexgrid_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."SAUID_HexGrid" \
                     ORDER BY "SAUID_HexGrid"."sauid" \

--- a/python/hmaps_postgres2es.py
+++ b/python/hmaps_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_hmaps",
+        view="opendrr_psra_hmaps_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM results_psra_national."psra_hmaps" \
                     ORDER BY "psra_hmaps"."geom" \

--- a/python/psra_postgres2es.py
+++ b/python/psra_postgres2es.py
@@ -10,6 +10,8 @@
 
 import utils
 
+config = utils.get_config_params('config.ini')
+version = config.get('es','version')
 
 def main():
     # building level aggregation
@@ -31,7 +33,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_b",
+        view="opendrr_psra_indicators_b_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_point) \
                 FROM results_psra_national.psra_indicators_b \
                 ORDER BY psra_indicators_b."AssetID" \
@@ -56,7 +58,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_s",
+        view="opendrr_psra_indicators_s_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom_poly) \
                     FROM results_psra_national.psra_indicators_s \
                     ORDER BY psra_indicators_s."Sauid" \
@@ -81,7 +83,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_csd",
+        view="opendrr_psra_indicators_csd_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM results_psra_national.psra_indicators_csd \
                     ORDER BY psra_indicators_csd."csduid" \
@@ -99,7 +101,7 @@ def main():
                 'number_of_replicas': 0
             }
         }),
-        view="opendrr_psra_agg_loss_fsa",
+        view="opendrr_psra_agg_loss_fsa_{}".format(version),
         sqlquerystring='SELECT * \
                     FROM results_psra_national.psra_agg_loss_fsa \
                     ORDER BY psra_agg_loss_fsa."fid" \
@@ -117,7 +119,7 @@ def main():
                 'number_of_replicas': 0
             }
         }),
-        view="opendrr_psra_expected_loss_fsa",
+        view="opendrr_psra_expected_loss_fsa_{}".format(version),
         sqlquerystring='SELECT * \
                     FROM results_psra_national.psra_expected_loss_fsa \
                     ORDER BY psra_expected_loss_fsa."fid" \
@@ -142,7 +144,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_1km",
+        view="opendrr_psra_indicators_hexgrid_1km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_1km \
@@ -168,7 +170,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_1km_uc",
+        view="opendrr_psra_indicators_hexgrid_1km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_1km_uc \
@@ -194,7 +196,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_5km",
+        view="opendrr_psra_indicators_hexgrid_5km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_5km \
@@ -220,7 +222,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_5km_uc",
+        view="opendrr_psra_indicators_hexgrid_5km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_5km_uc \
@@ -246,7 +248,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_10km",
+        view="opendrr_psra_indicators_hexgrid_10km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_10km \
@@ -272,7 +274,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_10km_uc",
+        view="opendrr_psra_indicators_hexgrid_10km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_10km_uc \
@@ -298,7 +300,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_25km",
+        view="opendrr_psra_indicators_hexgrid_25km_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_25km \
@@ -324,7 +326,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_25km_uc",
+        view="opendrr_psra_indicators_hexgrid_25km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_25km_uc \
@@ -350,7 +352,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_50km_uc",
+        view="opendrr_psra_indicators_hexgrid_50km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_50km_uc \
@@ -376,7 +378,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_indicators_hexgrid_100km_uc",
+        view="opendrr_psra_indicators_hexgrid_100km_uc_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
             FROM \
             results_psra_national.psra_indicators_hexgrid_100km_uc \
@@ -395,7 +397,7 @@ def main():
                 'number_of_replicas': 0
             }
         }),
-        view="opendrr_psra_canada_agg_loss",
+        view="opendrr_psra_canada_agg_loss_{}".format(version),
         sqlquerystring='SELECT * \
                     FROM results_psra_canada.psra_canada_agg_loss \
                     LIMIT {limit} \
@@ -412,7 +414,7 @@ def main():
                 'number_of_replicas': 0
             }
         }),
-        view="opendrr_psra_canada_expected_loss",
+        view="opendrr_psra_canada_expected_loss_{}".format(version),
         sqlquerystring='SELECT * \
                     FROM results_psra_canada.psra_canada_expected_loss \
                     LIMIT {limit} \
@@ -429,7 +431,7 @@ def main():
                 'number_of_replicas': 0
             }
         }),
-        view="opendrr_psra_canada_src_loss",
+        view="opendrr_psra_canada_src_loss_{}".format(version),
         sqlquerystring='SELECT * \
                     FROM results_psra_canada.psra_canada_src_loss \
                     LIMIT {limit} \

--- a/python/sample_config.ini
+++ b/python/sample_config.ini
@@ -18,3 +18,4 @@ es_un =
 es_pw = 
 es_endpoint = 
 kibana_endpoint = 
+version = 

--- a/python/sauid_postgres2es.py
+++ b/python/sauid_postgres2es.py
@@ -13,6 +13,9 @@ import utils
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
         utils.ESConnection(settings={
@@ -28,7 +31,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_geometry_sauid",
+        view="opendrr_geometry_sauid_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                     FROM boundaries."Geometry_SAUID" \
                     ORDER BY "Geometry_SAUID"."OBJECTID" \

--- a/python/socialFabric_postgres2es.py
+++ b/python/socialFabric_postgres2es.py
@@ -50,8 +50,9 @@ def main():
                     }
                 }
             }),
-            view="opendrr_nhsl_social_fabric_indicators_{agg}".format(**{
-                'agg': aggregation}),
+            view="opendrr_nhsl_social_fabric_indicators_{agg}_{version}".format(**{
+                'agg': aggregation,
+                'version': args.version}),
             sqlquerystring='SELECT *, ST_AsGeoJSON({geom}) \
                 FROM \
                 results_nhsl_social_fabric.nhsl_social_fabric_indicators_{agg} \
@@ -82,8 +83,9 @@ def main():
                     }
                 }
             }),
-            view="opendrr_nhsl_social_fabric_indicators_{agg}".format(**{
-                'agg': args.aggregation[0].lower()}),
+            view="opendrr_nhsl_social_fabric_indicators_{agg}_{version}".format(**{
+                'agg': args.aggregation[0].lower(),
+                'version': args.version}),
             sqlquerystring='SELECT *, ST_AsGeoJSON(geom_point) \
                 FROM \
                 results_nhsl_social_fabric.nhsl_social_fabric_indicators_{agg} \

--- a/python/srcLoss_postgres2es.py
+++ b/python/srcLoss_postgres2es.py
@@ -11,6 +11,8 @@
 import utils
 import argparse
 
+config = utils.get_config_params('config.ini')
+version = config.get('es','version')
 
 def main():
     # args = parse_args()
@@ -32,7 +34,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_src_loss",
+        view="opendrr_psra_src_loss_{}".format(version),
         sqlquerystring='SELECT * \
                 FROM results_psra_national.psra_src_loss \
                 ORDER BY psra_src_loss."fid" \

--- a/python/uhs_postgres2es.py
+++ b/python/uhs_postgres2es.py
@@ -13,6 +13,9 @@ import argparse
 
 
 def main():
+    config = utils.get_config_params('config.ini')
+    version = config.get('es','version')
+
     # args = parse_args()
     table = utils.PostGISdataset(
         utils.PostGISConnection(),
@@ -32,7 +35,7 @@ def main():
                 }
             }
         }),
-        view="opendrr_psra_uhs",
+        view="opendrr_psra_uhs_{}".format(version),
         sqlquerystring='SELECT *, ST_AsGeoJSON(geom) \
                 FROM results_psra_national.psra_uhs \
                 ORDER BY psra_uhs."geom" \


### PR DESCRIPTION
Add version number defined by config file to index names on loading into ES

No version change required as this does not change the underlying data, merely the way it is named in ElasticSearch

Future version could grab version directly from GithHub repo as a variable and pass that into python scripts as an argument. 